### PR TITLE
fix(evm): TxIndex is wrong when trace is the first tx of a block

### DIFF
--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -398,7 +398,10 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 
 	tx := req.Msg.AsTransaction()
 	txConfig.TxHash = tx.Hash()
-	txConfig.TxIndex++
+	if len(req.Predecessors) > 0 {
+		txConfig.TxIndex++
+	}
+
 	result, _, err := k.traceTx(ctx, cfg, txConfig, signer, tx, req.TraceConfig, false)
 	if err != nil {
 		// error will be returned with detail status from traceTx


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## Description

* Fix TxIndex wrongly when trace first Tx of a block

If `Predecessors` is empty, `txConfig.TxIndex` originally = 0 and when it reachs line 401 `txConfig.TxIndex++`, it will becomes 1. It should be 0

* apply suggestion and add change-log

* fix comment


______

For contributor use:

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [X] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [X] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [X] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [x] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [x] Reviewers assigned
- [x] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
